### PR TITLE
Remove simple translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Entering "abc" into a currency field would result in:
 
 ```json
 {
-  error: ["is required"],
+  error: ["FormFormatters.required"],
   formatted: "abc",
   parsed: "abc",
   valid: false

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "lodash": "4.17.5",
     "moment": "2.21.0",
-    "numeral": "2.0.6",
-    "simple-translator": "0.2.0"
+    "numeral": "2.0.6"
   },
   "devDependencies": {
     "ava": "0.25.0",

--- a/src/formatters/currency.js
+++ b/src/formatters/currency.js
@@ -1,6 +1,5 @@
 import { isNil } from "lodash";
 import Numeral from "numeral";
-import Translator from "simple-translator";
 import NumberFormatter from "./number";
 
 const CurrencyFormatter = {
@@ -18,7 +17,7 @@ const CurrencyFormatter = {
         formatted = value || "";
         if(options.required && valid) {
           valid = false;
-          errors.push(Translator.translate("FormFormatters.required"));
+          errors.push("FormFormatters.required");
         }
       }
       formatted = numObj.format("$0,0.00");

--- a/src/formatters/date.js
+++ b/src/formatters/date.js
@@ -1,6 +1,5 @@
 import Moment from "moment";
 import StrFormatter from "./string";
-import Translator from "simple-translator";
 import { isNil } from "lodash";
 
 const DateFormatter = {
@@ -28,7 +27,7 @@ const DateFormatter = {
         }
       } else {
         valid = false;
-        errors.push(Translator.translate("FormFormatters.dateInvalid"));
+        errors.push("FormFormatters.dateInvalid");
       }
     }
 

--- a/src/formatters/email.js
+++ b/src/formatters/email.js
@@ -1,4 +1,3 @@
-import Translator from "simple-translator";
 import StrFormatter from "./string";
 
 const EmailFormatter = {
@@ -12,7 +11,7 @@ const EmailFormatter = {
       let emailRegex = /^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\.[A-Za-z]+$/;
       valid = emailRegex.test(formatted);
       if(!valid) {
-        errors.push(Translator.translate("FormFormatters.emailInvalid"));
+        errors.push("FormFormatters.emailInvalid");
       }
     }
 

--- a/src/formatters/hex.js
+++ b/src/formatters/hex.js
@@ -1,4 +1,3 @@
-import Translator from "simple-translator";
 import StrFormatter from "./string";
 
 const HexFormatter = {
@@ -15,7 +14,7 @@ const HexFormatter = {
         valid = false;
       }
       if(!valid) {
-        errors.push(Translator.translate("FormFormatters.hexInvalid"));
+        errors.push("FormFormatters.hexInvalid");
       }
     }
 

--- a/src/formatters/number.js
+++ b/src/formatters/number.js
@@ -1,5 +1,4 @@
 import numeral from "numeral";
-import Translator from "simple-translator";
 import StrFormatter from "./string";
 
 const NumberFormatter = {
@@ -13,7 +12,7 @@ const NumberFormatter = {
         formatted = value;
         if(options.required) {
           valid = false;
-          errors.push(Translator.translate("FormFormatters.required"));
+          errors.push("FormFormatters.required");
         }
       }
       formatted = parsed.toString();

--- a/src/formatters/percent.js
+++ b/src/formatters/percent.js
@@ -1,21 +1,20 @@
-import _ from "lodash";
 import numeral from "numeral";
-import Translator from "simple-translator";
 import StrFormatter from "./string";
+import { merge, isEmpty, trim } from "lodash";
 
 const PercentFormatter = {
   format(value, options = {}) {
-    options = _.merge({}, {format: "decimal"}, options);
+    options = merge({}, {format: "decimal"}, options);
     let{valid, parsed, formatted, errors} = StrFormatter.format(value, options);
 
-    if(!_.isEmpty(parsed)) {
-      let numObj = numeral(_.trim(parsed.replace(/[$\s,%]/g, "")));
+    if(!isEmpty(parsed)) {
+      let numObj = numeral(trim(parsed.replace(/[$\s,%]/g, "")));
       parsed = numObj.value();
       if(typeof(parsed) === "undefined" || parsed === null) {
         parsed = value;
         formatted = value;
         valid = false;
-        errors.push(Translator.translate("FormFormatters.required"));
+        errors.push("FormFormatters.required");
       } else {
         if(options.format === "decimal") {
           formatted = numObj.format("0,0.00");

--- a/src/formatters/phone.js
+++ b/src/formatters/phone.js
@@ -1,4 +1,3 @@
-import Translator from "simple-translator";
 import StrFormatter from "./string";
 
 const PhoneFormatter = {
@@ -13,7 +12,7 @@ const PhoneFormatter = {
         valid = false;
         parsed = value;
         formatted = value;
-        errors.push(Translator.translate("FormFormatters.phoneInvalid"));
+        errors.push("FormFormatters.phoneInvalid");
       }
     }
 

--- a/src/formatters/rgb.js
+++ b/src/formatters/rgb.js
@@ -1,5 +1,4 @@
 import numeral from "numeral";
-import Translator from "simple-translator";
 import NumberFormatter from "./number";
 
 const RgbFormatter = {
@@ -14,11 +13,11 @@ const RgbFormatter = {
         formatted = value || "";
         if(options.required && valid) {
           valid = false;
-          errors.push(Translator.translate("FormFormatters.required"));
+          errors.push("FormFormatters.required");
         }
       } else if(parsed > 255 || parsed < 0) {
         valid = false;
-        errors.push(Translator.translate("FormFormatters.rgbInvalid"));
+        errors.push("FormFormatters.rgbInvalid");
       }
     }
 

--- a/src/formatters/ssn.js
+++ b/src/formatters/ssn.js
@@ -1,5 +1,4 @@
 import StrFormatter from "./string";
-import Translator from "simple-translator";
 
 const SSNFormatter = {
   format(value, options = {}) {
@@ -13,7 +12,7 @@ const SSNFormatter = {
         valid = false;
         parsed = value;
         formatted = value;
-        errors.push(Translator.translate("FormFormatters.ssnInvalid"));
+        errors.push("FormFormatters.ssnInvalid");
       }
     }
 

--- a/src/formatters/ssnLastFour.js
+++ b/src/formatters/ssnLastFour.js
@@ -1,5 +1,4 @@
 import StringFormatter from "./string";
-import Translator from "simple-translator";
 
 const SSNLastFourFormatter = {
   format(value, options = {}) {
@@ -12,7 +11,7 @@ const SSNLastFourFormatter = {
       if(parsed.length !== 4) {
         valid = false;
         errors.push();
-        errors.push(Translator.translate("FormFormatters.last4Invalid"));
+        errors.push("FormFormatters.last4Invalid");
       }
     }
 

--- a/src/formatters/string.js
+++ b/src/formatters/string.js
@@ -1,5 +1,4 @@
 import { isEmpty, isNil, isNumber } from "lodash";
-import Translator from "simple-translator";
 
 const StringFormatter = {
   format(value, options = {}) {
@@ -18,7 +17,7 @@ const StringFormatter = {
     let formatted = isNil(value) ? "" : value.toString().trim();
     let parsed = formatted;
     if(options.required && isEmpty(parsed)) {
-      errors.push(Translator.translate("FormFormatters.required"));
+      errors.push("FormFormatters.required");
     }
 
     return({

--- a/src/formatters/time.js
+++ b/src/formatters/time.js
@@ -1,6 +1,5 @@
 import Moment from "moment";
 import StrFormatter from "./string";
-import Translator from "simple-translator";
 
 const TimeFormatter = {
   timeFormat: "h:mm a",
@@ -17,7 +16,7 @@ const TimeFormatter = {
         valid = false;
         formatted = "";
         parsed = "";
-        errors.push(Translator.translate("FormFormatters.timeInvalid"));
+        errors.push("FormFormatters.timeInvalid");
       }
     }
 

--- a/test/formatters/currency.js
+++ b/test/formatters/currency.js
@@ -1,18 +1,9 @@
 import formatter from "../../src/formatters/currency";
-import Translator from "simple-translator"; 
 import test from "ava";
 
-const English = {
-  FormFormatters: {
-    required: "is required"
-  }
-};
-
 test("converts null", t => {
-  Translator.registerDefaultLanguage("en", English);
-
   t.deepEqual(formatter.format(null, {required: true}), {
-    errors: ["is required"],
+    errors: ["FormFormatters.required"],
     formatted: "",
     parsed: "",
     valid: false
@@ -20,10 +11,8 @@ test("converts null", t => {
 });
 
 test("returns an error if required", t => {
-  Translator.registerDefaultLanguage("en", English);
-
   t.deepEqual(formatter.format("", {required: true}), {
-    errors: ["is required"],
+    errors: ["FormFormatters.required"],
     formatted: "",
     parsed: "",
     valid: false
@@ -67,10 +56,8 @@ test("formats dollars", t => {
 });
 
 test("(doesn't) handle errors", t => {
-  Translator.registerDefaultLanguage("en", English);
-
   t.deepEqual(formatter.format("abc", {required: true}), {
-    errors: ["is required"],
+    errors: ["FormFormatters.required"],
     formatted: "abc",
     parsed: "abc",
     valid: false

--- a/test/formatters/date.js
+++ b/test/formatters/date.js
@@ -1,19 +1,9 @@
 import formatter from "../../src/formatters/date";
-import Translator from "simple-translator"; 
 import test from "ava";
 
-const English = {
-  FormFormatters: {
-    dateInvalid: "date is invalid",
-    required: "is required"
-  }
-};
-
 test("converts null", t => {
-  Translator.registerDefaultLanguage("en", English);
-
   t.deepEqual(formatter.format(null, {required: true}), {
-    errors: ["is required"],
+    errors: ["FormFormatters.required"],
     formatted: "",
     parsed: "",
     valid: false
@@ -21,10 +11,8 @@ test("converts null", t => {
 });
 
 test("returns an error if required", t => {
-  Translator.registerDefaultLanguage("en", English);
-
   t.deepEqual(formatter.format("", {required: true}), {
-    errors: ["is required"],
+    errors: ["FormFormatters.required"],
     formatted: "",
     parsed: "",
     valid: false
@@ -104,10 +92,8 @@ test("formats MMM DD YYYY h:mm", t => {
 });
 
 test("does not handle errors", t => {
-  Translator.registerDefaultLanguage("en", English);
-
   t.deepEqual(formatter.format("abc"), {
-    errors: ["date is invalid"],
+    errors: ["FormFormatters.dateInvalid"],
     formatted: "",
     parsed: "",
     valid: false


### PR DESCRIPTION
The developer should be allowed to use any translation method they desire.
So removing simple translator leaves it in their court for decision making.