### PR TITLE
Add converters for additional input types

### DIFF
--- a/src/converters/creditCard.js
+++ b/src/converters/creditCard.js
@@ -1,0 +1,6 @@
+import CreditCardFormatter from "../formatters/creditCard";
+
+export default function(value) {
+  let formatterObj = {errors: [], formatted: value, parsed: value};
+  return CreditCardFormatter(formatterObj).formatted;
+}

--- a/src/converters/currency.js
+++ b/src/converters/currency.js
@@ -1,0 +1,10 @@
+import CurrencyFormatter from "../formatters/currency";
+import { isNil } from "lodash";
+
+export default function(value) {
+  if(!isNil(value)) {
+    value = value.toString();
+  }
+  let formatterObj = {errors: [], formatted: value, parsed: value};
+  return CurrencyFormatter(formatterObj).formatted;
+}

--- a/src/converters/hex.js
+++ b/src/converters/hex.js
@@ -1,0 +1,6 @@
+import HexFormatter from "../formatters/hex";
+
+export default function(value) {
+  let formatterObj = {errors: [], formatted: value, parsed: value};
+  return HexFormatter(formatterObj).formatted;
+}

--- a/src/converters/percent.js
+++ b/src/converters/percent.js
@@ -1,0 +1,6 @@
+import PercentFormatter from "../formatters/percent";
+
+export default function(value) {
+  let formatterObj = {errors: [], formatted: value, parsed: value};
+  return PercentFormatter(formatterObj).formatted;
+}

--- a/src/converters/phone.js
+++ b/src/converters/phone.js
@@ -1,0 +1,6 @@
+import PhoneFormatter from "../formatters/phone";
+
+export default function(value) {
+  let formatterObj = {errors: [], formatted: value, parsed: value};
+  return PhoneFormatter(formatterObj).formatted;
+}

--- a/src/converters/phoneString.js
+++ b/src/converters/phoneString.js
@@ -1,0 +1,6 @@
+import PhoneStringFormatter from "../formatters/phoneString";
+
+export default function(value) {
+  let formatterObj = {errors: [], formatted: value, parsed: value};
+  return PhoneStringFormatter(formatterObj).formatted;
+}

--- a/src/converters/ssn.js
+++ b/src/converters/ssn.js
@@ -1,0 +1,6 @@
+import SsnFormatter from "../formatters/ssn";
+
+export default function(value) {
+  let formatterObj = {errors: [], formatted: value, parsed: value};
+  return SsnFormatter(formatterObj).formatted;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,25 @@
 import ArrayFormatter from "./formatters/array";
+import CreditCardConverter from "./converters/creditCard";
 import CreditCardFormatter from "./formatters/creditCard";
+import CurrencyConverter from "./converters/currency";
 import CurrencyFormatter from "./formatters/currency";
 import DateConverter from "./converters/date";
 import DateFormatter from "./formatters/date";
 import EmailFormatter from "./formatters/email";
+import HexConverter from "./converters/hex";
 import HexFormatter from "./formatters/hex";
 import MonthYearFormatter from "./formatters/monthYear";
 import NameFormatter from "./formatters/name";
 import NumberFormatter from "./formatters/number";
+import PercentConverter from "./converters/percent";
 import PercentFormatter from "./formatters/percent";
+import PhoneConverter from "./converters/phone";
 import PhoneFormatter from "./formatters/phone";
+import PhoneStringConverter from "./converters/phoneString";
 import PhoneStringFormatter from "./formatters/phoneString";
 import RequiredFormatter from "./formatters/required";
 import RgbFormatter from "./formatters/rgb";
+import SsnConverter from "./converters/ssn";
 import SsnFormatter from "./formatters/ssn";
 import SsnLastFourFormatter from "./formatters/ssnLastFour";
 import StringFormatter from "./formatters/string";
@@ -22,8 +29,10 @@ import WholeNumberFormatter from "./formatters/whole";
 module.exports = {
   ArrayFormatter: ArrayFormatter,
   ArrayMask: require("./masks/array"),
+  CreditCardConverter: CreditCardConverter,
   CreditCardFormatter: CreditCardFormatter,
   CreditCardMask: require("./masks/creditCard"),
+  CurrencyConverter: CurrencyConverter,
   CurrencyFormatter: CurrencyFormatter,
   CurrencyMask: require("./masks/currency"),
   DecimalMask: require("./masks/decimal"),
@@ -32,20 +41,25 @@ module.exports = {
   EmailFormatter: EmailFormatter,
   EmailMask: require("./masks/email"),
   EnglishTranslation: require("./utils/translations/en"),
+  HexConverter: HexConverter,
   HexFormatter: HexFormatter,
   HexMask: require("./masks/hex"),
   MonthYearFormatter: MonthYearFormatter,
   NameFormatter: NameFormatter,
   NumberFormatter: NumberFormatter,
   NumberMask: require("./masks/number"),
+  PercentConverter: PercentConverter,
   PercentFormatter: PercentFormatter,
   PercentMask: require("./masks/percent"),
+  PhoneConverter: PhoneConverter,
   PhoneFormatter: PhoneFormatter,
-  PhoneStringFormatter: PhoneStringFormatter,
   PhoneMask: require("./masks/phone"),
+  PhoneStringConverter: PhoneStringConverter,
+  PhoneStringFormatter: PhoneStringFormatter,
   PhoneStringMask: require("./masks/phoneString"),
   RequiredFormatter: RequiredFormatter,
   RgbFormatter: RgbFormatter,
+  SsnConverter: SsnConverter,
   SsnFormatter: SsnFormatter,
   SsnMask: require("./masks/ssn"),
   SsnLastFourFormatter: SsnLastFourFormatter,

--- a/test/converters/creditCard.js
+++ b/test/converters/creditCard.js
@@ -1,0 +1,30 @@
+import test from "ava";
+import { CreditCardConverter } from "../../src";
+
+test("handles null", t => {
+  t.deepEqual(CreditCardConverter(null), null);
+});
+
+test("does not return an error if blank", t => {
+  t.deepEqual(CreditCardConverter(""), "");
+});
+
+test("converts and formats number", t => {
+  t.deepEqual(CreditCardConverter(4583944000348272), "4583 9440 0034 8272");
+});
+
+test("formats strings without spaces", t => {
+  t.deepEqual(CreditCardConverter("1111222233334444"), "1111 2222 3333 4444");
+});
+
+test("preserves formatted strings with spaces", t => {
+  t.deepEqual(CreditCardConverter("1111 2222 3333 4444"), "1111 2222 3333 4444");
+});
+
+test("converts and formats AMEX number", t => {
+  t.deepEqual(CreditCardConverter(341111111111111), "3411 111111 11111");
+});
+
+test("preserves formatted AMEX card string", t => {
+  t.deepEqual(CreditCardConverter("3711 111111 11111"), "3711 111111 11111");
+});

--- a/test/converters/currency.js
+++ b/test/converters/currency.js
@@ -1,0 +1,34 @@
+import { CurrencyConverter } from "../../src";
+import test from "ava";
+
+test("handles null", t => {
+  t.deepEqual(CurrencyConverter(null), null);
+});
+
+test("returns a empty string", t => {
+  t.deepEqual(CurrencyConverter(""), "");
+});
+
+test("converts unformatted string", t => {
+  t.deepEqual(CurrencyConverter("1112223333"), "1,112,223,333.00");
+});
+
+test("preserves formatted string", t => {
+  t.deepEqual(CurrencyConverter("1,112,223,333.00"), "1,112,223,333.00");
+});
+
+test("converts and formats numbers", t => {
+  t.deepEqual(CurrencyConverter(1112223333), "1,112,223,333.00");
+});
+
+test("converts and formats number less than 1", t => {
+  t.deepEqual(CurrencyConverter(.25), "0.25");
+});
+
+test("formats cents", t => {
+  t.deepEqual(CurrencyConverter("$5.14"), "5.14");
+});
+
+test("formats zero cents", t => {
+  t.deepEqual(CurrencyConverter("5"), "5.00");
+});

--- a/test/converters/hex.js
+++ b/test/converters/hex.js
@@ -1,0 +1,18 @@
+import { HexConverter } from "../../src";
+import test from "ava";
+
+test("accepts null", t => {
+  t.deepEqual(HexConverter(null), null);
+});
+
+test("does not return an error if empty string", t => {
+  t.deepEqual(HexConverter(""), "");
+});
+
+test("converts and formats number", t => {
+  t.deepEqual(HexConverter(666666), "#666666");
+});
+
+test("preserves hash tag", t => {
+  t.deepEqual(HexConverter("#666666"), "#666666");
+});

--- a/test/converters/percent.js
+++ b/test/converters/percent.js
@@ -1,0 +1,22 @@
+import { PercentConverter } from "../../src";
+import test from "ava";
+
+test("handles null", t => {
+  t.deepEqual(PercentConverter(null), null);
+});
+
+test("handles empty string", t => {
+  t.deepEqual(PercentConverter(""), "");
+});
+
+test("converts number value", t => {
+  t.deepEqual(PercentConverter(12.33), "12.33%");
+});
+
+test("converts string value", t => {
+  t.deepEqual(PercentConverter("45"), "45%");
+});
+
+test("preserves %", t => {
+  t.deepEqual(PercentConverter("25%"), "25%");
+});

--- a/test/converters/phone.js
+++ b/test/converters/phone.js
@@ -1,0 +1,18 @@
+import test from "ava";
+import { PhoneConverter } from "../../src";
+
+test("handles null", t => {
+  t.deepEqual(PhoneConverter(null), null);
+});
+
+test("handles empty string", t => {
+  t.deepEqual(PhoneConverter(""), "");
+});
+
+test("converts and formats number", t => {
+  t.deepEqual(PhoneConverter(1112223333), "(111) 222-3333");
+});
+
+test("formats strings", t => {
+  t.deepEqual(PhoneConverter("1112223333"), "(111) 222-3333");
+});

--- a/test/converters/phoneString.js
+++ b/test/converters/phoneString.js
@@ -1,0 +1,30 @@
+import test from "ava";
+import { PhoneStringConverter } from "../../src";
+
+test("handles null", t => {
+  t.deepEqual(PhoneStringConverter(null), null);
+});
+
+test("handles empty string", t => {
+  t.deepEqual(PhoneStringConverter(""), "");
+});
+
+test("converts and formats number", t => {
+  t.deepEqual(PhoneStringConverter(1112223333), "(111) 222-3333");
+});
+
+test("formats dash formatted strings", t => {
+  t.deepEqual(PhoneStringConverter("111-222-3333"), "(111) 222-3333");
+});
+
+test("formats space formatted strings", t => {
+  t.deepEqual(PhoneStringConverter("111 222-3333"), "(111) 222-3333");
+});
+
+test("formats dot formatted strings", t => {
+  t.deepEqual(PhoneStringConverter("111.222.3333"), "(111) 222-3333");
+});
+
+test("formats unformatted strings", t => {
+  t.deepEqual(PhoneStringConverter("1112223333"), "(111) 222-3333");
+});

--- a/test/converters/ssn.js
+++ b/test/converters/ssn.js
@@ -1,0 +1,22 @@
+import test from "ava";
+import { SsnConverter } from "../../src";
+
+test("accepts null", t => {
+  t.deepEqual(SsnConverter(null), null);
+});
+
+test("accepts empty string", t => {
+  t.deepEqual(SsnConverter(""), "");
+});
+
+test("converts and formats number", t => {
+  t.deepEqual(SsnConverter(123456789), "123-45-6789");
+});
+
+test("formats unformatted strings", t => {
+  t.deepEqual(SsnConverter("111223333"), "111-22-3333");
+});
+
+test("preserves formatted strings", t => {
+  t.deepEqual(SsnConverter("111-22-3333"), "111-22-3333");
+});


### PR DESCRIPTION
This PR is intended to be a non-breaking change both for form-formatters and with regard to its use with form-linker.

Problem: Several data types are not displaying correctly when initially loaded into a form from the api. Form-linker relies on form-formatter's converters to process raw api data into a format for display in the UI but converters do not yet exist for most data types. 

Proposed solution: Create converters for applicable data types. Since formatters already perform formatting & validation, most converters can rely on the corresponding formatter under the hood. For example, the new Currency converter initially converts a number value to a string and then hands it off to the Currency formatter, but instead of returning the formatter object it returns only the formatted value. This will ensure consistency of formatting form values in the UI without breaking existing implementations of form-linker or form-formatters.
