### PR TITLE
phone string formatter

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,3 @@ jobs:
             - node_modules
       - run: npm test
       - run: npm run lint
-      - run: npm run security

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "lint": "eslint src",
     "build": "babel src --out-dir dist",
-    "security": "node_modules/nsp/bin/nsp check",
     "test": "ava"
   },
   "dependencies": {

--- a/src/formatters/phoneString.js
+++ b/src/formatters/phoneString.js
@@ -6,9 +6,10 @@ export default function({errors, formatted: value, parsed}) {
   if(!isNil(value) && value !== "") {
     // remove all non-digits
     let sanitized = value.toString().replace(/\D/g, "");
-    parsed = sanitized.replace(/(\d{3})(\d{3})(\d{4})/, "$1-$2-$3");
     formatted = sanitized.replace(/(\d{3})(\d{3})(\d{4})/, "($1) $2-$3");
-    if(parsed.length !== 12) {
+    parsed = formatted;
+
+    if(parsed.length !== 14) {
       parsed = value;
       formatted = value;
       errors.push("FormFormatters.phoneInvalid");

--- a/test/formatters/phoneString.js
+++ b/test/formatters/phoneString.js
@@ -32,7 +32,7 @@ test("trims white space", t => {
   t.deepEqual(PhoneStringFormatter({errors: [], valid: true, formatted: " 1112223333 ", parsed: " 1112223333 "}), {
     errors: [],
     formatted: "(111) 222-3333",
-    parsed: "111-222-3333",
+    parsed: "(111) 222-3333",
     valid: true
   });
 });
@@ -41,7 +41,7 @@ test("formats strings", t => {
   t.deepEqual(PhoneStringFormatter({errors: [], valid: true, formatted: "1112223333", parsed: "1112223333"}), {
     errors: [],
     formatted: "(111) 222-3333",
-    parsed: "111-222-3333",
+    parsed: "(111) 222-3333",
     valid: true
   });
 });


### PR DESCRIPTION
This PR changes the phone string formatter so that the parsed data and formatted data match. This way a phone number can be saved to the database formatted. This will help us stay consistent with formatting. Phone numbers are displayed with parenthesis and dashes, so it doesn't make sense to have a formatter that saves phone numbers with only dashes. 