### PR TITLE
use local time not UTC

### DIFF
--- a/src/converters/date.js
+++ b/src/converters/date.js
@@ -3,7 +3,7 @@ import { isNil } from "lodash";
 
 export default function(value) {
   if(!isNil(value) && value !== "") {
-    let temp = Moment.unix(value).utc();
+    let temp = Moment.unix(value);
     if(temp.isValid()) {
       value = temp.clone().format("MMM D, YYYY");
     }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -2,7 +2,7 @@ import Moment from "moment";
 
 module.exports = {
   parse(date) {
-    return Moment.utc(date, [
+    return Moment(date, [
       // dates
       "MMDDYYYY",
       "MMM YYYY",

--- a/test/converters/date.js
+++ b/test/converters/date.js
@@ -2,15 +2,15 @@ import { DateConverter } from "../../src";
 import test from "ava";
 
 test("accepts epoch", t => {
-  t.deepEqual(DateConverter(1672531200), "Jan 1, 2023");
+  t.deepEqual(DateConverter(1672556400), "Jan 1, 2023");
 });
 
 test("accepts string epoch", t => {
-  t.deepEqual(DateConverter("1672531200"), "Jan 1, 2023");
+  t.deepEqual(DateConverter("1672556400"), "Jan 1, 2023");
 });
 
 test("accepts num", t => {
-  t.deepEqual(DateConverter(23), "Jan 1, 1970");
+  t.deepEqual(DateConverter(23), "Dec 31, 1969");
 });
 
 test("accepts null", t => {

--- a/test/formatters/date.js
+++ b/test/formatters/date.js
@@ -32,7 +32,7 @@ test("converts number", t => {
   t.deepEqual(DateFormatter({errors: [], valid: true, formatted: 23, parsed: 23}), {
     errors: [],
     formatted: "Jan 1, 2023",
-    parsed: 1672531200,
+    parsed: 1672556400,
     valid: true
   });
 });
@@ -41,7 +41,7 @@ test("trims white space", t => {
   t.deepEqual(DateFormatter({errors: [], valid: true, formatted: " 1112223333 ", parsed: " 1112223333 "}), {
     errors: [],
     formatted: "Nov 12, 2233",
-    parsed: 8326713600,
+    parsed: 8326738800,
     valid: true
   });
 });
@@ -50,7 +50,7 @@ test("formats dates", t => {
   t.deepEqual(DateFormatter({errors: [], valid: true, formatted: "5-5-14", parsed: "5-5-14"}), {
     errors: [],
     formatted: "May 5, 2014",
-    parsed: 1399248000,
+    parsed: 1399273200,
     valid: true
   });
 });
@@ -59,7 +59,7 @@ test("formats MMDDYYYY", t => {
   t.deepEqual(DateFormatter({errors: [], valid: true, formatted: "05052014", parsed: "05052014"}), {
     errors: [],
     formatted: "May 5, 2014",
-    parsed: 1399248000,
+    parsed: 1399273200,
     valid: true
   });
 });
@@ -68,7 +68,7 @@ test("formats MMM YYYY", t => {
   t.deepEqual(DateFormatter({errors: [], valid: true, formatted: "May 2014", parsed: "May 2014"}), {
     errors: [],
     formatted: "May 1, 2014",
-    parsed: 1398902400,
+    parsed: 1398927600,
     valid: true
   });
 });
@@ -77,7 +77,7 @@ test("formats MMM DD YYYY", t => {
   t.deepEqual(DateFormatter({errors: [], valid: true, formatted: "May 5 2014", parsed: "May 5 2014"}), {
     errors: [],
     formatted: "May 5, 2014",
-    parsed: 1399248000,
+    parsed: 1399273200,
     valid: true
   });
 });
@@ -86,7 +86,7 @@ test("formats MMM DD YYYY h:mm", t => {
   t.deepEqual(DateFormatter({errors: [], valid: true, formatted: "May 5 2014 12:00", parsed: "May 5 2014 12:00"}), {
     errors: [],
     formatted: "May 5, 2014",
-    parsed: 1399248000,
+    parsed: 1399273200,
     valid: true
   });
 });


### PR DESCRIPTION
Parsing dates in UTC mode seems to create undesired results. When a date is submitted, the conversion to epoch implicitly sets the time to 0:00:00 on that date. But doing it in UTC mode generates an epoch value corresponding to the previous day where the user is located, which is counter to their expectations. This also causes issues with the UI. For example, using a date picker with a minDate of tomorrow allows the user to select tomorrow's date, but in doing so the value sent to the back end is the epoch value for tomorrow at midnight **UTC**, which for anywhere in the US is going to be some number of hours before the end of the current day. Consequently, the server throws an exception because the submitted epoch value is for the current day locally.

This PR will cause dates to be parsed in local mode. Thus, when the user selects a date, for example March 16, 2020, the epoch value generated will be the value corresponding to 3/16/2020 0:00:00 in the user's time zone instead of 3/16/2020 0:00:00 GMT. 